### PR TITLE
Remove UnsafeCursor from the JNI API

### DIFF
--- a/okio-zstd/src/commonMain/kotlin/okio/zstd/ZstdCompressSink.kt
+++ b/okio-zstd/src/commonMain/kotlin/okio/zstd/ZstdCompressSink.kt
@@ -99,16 +99,29 @@ internal class ZstdCompressSink internal constructor(
           // Compress some input. This might not produce any output!
           inputBuffer.readUnsafe(inputCursor).use { inputCursor ->
             inputCursor.next()
-            result = compressor.compressStream2(outputCursor, inputCursor, mode)
+            result = compressor.compressStream2(
+              outputByteArray = outputCursor.data!!,
+              outputEnd = outputCursor.end,
+              outputStart = outputCursor.start,
+              inputByteArray = inputCursor.data!!,
+              inputEnd = inputCursor.end,
+              inputStart = inputCursor.start,
+              mode = mode,
+            )
           }
           inputRemaining -= compressor.inputBytesProcessed
           inputBuffer.skip(compressor.inputBytesProcessed.toLong())
         } else {
           // No more input, but possibly more output.
-          inputCursor.data = emptyByteArray
-          inputCursor.start = 0
-          inputCursor.end = 0
-          result = compressor.compressStream2(outputCursor, inputCursor, mode)
+          result = compressor.compressStream2(
+            outputByteArray = outputCursor.data!!,
+            outputEnd = outputCursor.end,
+            outputStart = outputCursor.start,
+            inputByteArray = emptyByteArray,
+            inputEnd = 0,
+            inputStart = 0,
+            mode = mode,
+          )
         }
 
         outputCursor.resizeBuffer(outputSizeBefore + compressor.outputBytesProcessed)

--- a/okio-zstd/src/commonMain/kotlin/okio/zstd/ZstdCompressor.kt
+++ b/okio-zstd/src/commonMain/kotlin/okio/zstd/ZstdCompressor.kt
@@ -16,7 +16,6 @@
 package okio.zstd
 
 import kotlin.jvm.JvmField
-import okio.Buffer.UnsafeCursor
 import okio.Closeable
 
 internal abstract class ZstdCompressor : Closeable {
@@ -33,8 +32,12 @@ internal abstract class ZstdCompressor : Closeable {
 
   /** @param mode one of [ZSTD_e_continue], [ZSTD_e_flush], or [ZSTD_e_end]. */
   abstract fun compressStream2(
-    output: UnsafeCursor,
-    input: UnsafeCursor,
+    outputByteArray: ByteArray,
+    outputEnd: Int,
+    outputStart: Int,
+    inputByteArray: ByteArray,
+    inputEnd: Int,
+    inputStart: Int,
     mode: Int,
   ): Long
 }

--- a/okio-zstd/src/commonMain/kotlin/okio/zstd/ZstdDecompressSource.kt
+++ b/okio-zstd/src/commonMain/kotlin/okio/zstd/ZstdDecompressSource.kt
@@ -87,7 +87,14 @@ internal class ZstdDecompressSource internal constructor(
 
         source.buffer.readUnsafe(inputCursor).use { inputCursor ->
           inputCursor.next()
-          result = decompressor.decompressStream(outputCursor, inputCursor)
+          result = decompressor.decompressStream(
+            outputByteArray = outputCursor.data!!,
+            outputEnd = outputCursor.end,
+            outputStart = outputCursor.start,
+            inputByteArray = inputCursor.data!!,
+            inputEnd = inputCursor.end,
+            inputStart = inputCursor.start,
+          )
         }
         source.skip(decompressor.inputBytesProcessed.toLong())
 

--- a/okio-zstd/src/commonMain/kotlin/okio/zstd/ZstdDecompressor.kt
+++ b/okio-zstd/src/commonMain/kotlin/okio/zstd/ZstdDecompressor.kt
@@ -16,7 +16,6 @@
 package okio.zstd
 
 import kotlin.jvm.JvmField
-import okio.Buffer.UnsafeCursor
 import okio.Closeable
 
 internal abstract class ZstdDecompressor : Closeable {
@@ -29,7 +28,11 @@ internal abstract class ZstdDecompressor : Closeable {
   var outputBytesProcessed: Int = -1
 
   abstract fun decompressStream(
-    output: UnsafeCursor,
-    input: UnsafeCursor,
+    outputByteArray: ByteArray,
+    outputEnd: Int,
+    outputStart: Int,
+    inputByteArray: ByteArray,
+    inputEnd: Int,
+    inputStart: Int,
   ): Long
 }

--- a/okio-zstd/src/jniMain/kotlin/okio/zstd/JniZstdCompressor.kt
+++ b/okio-zstd/src/jniMain/kotlin/okio/zstd/JniZstdCompressor.kt
@@ -15,8 +15,6 @@
  */
 package okio.zstd
 
-import okio.Buffer.UnsafeCursor
-
 internal class JniZstdCompressor : ZstdCompressor() {
   @JvmField
   var cctxPointer = createZstdCompressor()
@@ -27,10 +25,24 @@ internal class JniZstdCompressor : ZstdCompressor() {
   override fun setParameter(param: Int, value: Int): Long = setParameter(cctxPointer, param, value)
 
   override fun compressStream2(
-    output: UnsafeCursor,
-    input: UnsafeCursor,
+    outputByteArray: ByteArray,
+    outputEnd: Int,
+    outputStart: Int,
+    inputByteArray: ByteArray,
+    inputEnd: Int,
+    inputStart: Int,
     mode: Int,
-  ): Long = compressStream2(jniZstdPointer, cctxPointer, output, input, mode)
+  ): Long = compressStream2(
+    jniPointer = jniZstdPointer,
+    cctxPointer = cctxPointer,
+    outputByteArray = outputByteArray,
+    outputEnd = outputEnd,
+    outputStart = outputStart,
+    inputByteArray = inputByteArray,
+    inputEnd = inputEnd,
+    inputStart = inputStart,
+    mode = mode,
+  )
 
   override fun close() {
     val cctxPointerToClose = cctxPointer
@@ -45,8 +57,12 @@ internal class JniZstdCompressor : ZstdCompressor() {
   private external fun compressStream2(
     jniPointer: Long,
     cctxPointer: Long,
-    output: UnsafeCursor,
-    input: UnsafeCursor,
+    outputByteArray: ByteArray,
+    outputEnd: Int,
+    outputStart: Int,
+    inputByteArray: ByteArray,
+    inputEnd: Int,
+    inputStart: Int,
     mode: Int,
   ): Long
 

--- a/okio-zstd/src/jniMain/kotlin/okio/zstd/JniZstdDecompressor.kt
+++ b/okio-zstd/src/jniMain/kotlin/okio/zstd/JniZstdDecompressor.kt
@@ -15,8 +15,6 @@
  */
 package okio.zstd
 
-import okio.Buffer.UnsafeCursor
-
 internal class JniZstdDecompressor : ZstdDecompressor() {
   @JvmField
   var dctxPointer = createZstdDecompressor()
@@ -25,9 +23,22 @@ internal class JniZstdDecompressor : ZstdDecompressor() {
     }
 
   override fun decompressStream(
-    output: UnsafeCursor,
-    input: UnsafeCursor,
-  ): Long = decompressStream(jniZstdPointer, dctxPointer, output, input)
+    outputByteArray: ByteArray,
+    outputEnd: Int,
+    outputStart: Int,
+    inputByteArray: ByteArray,
+    inputEnd: Int,
+    inputStart: Int,
+  ): Long = decompressStream(
+    jniPointer = jniZstdPointer,
+    dctxPointer = dctxPointer,
+    outputByteArray = outputByteArray,
+    outputEnd = outputEnd,
+    outputStart = outputStart,
+    inputByteArray = inputByteArray,
+    inputEnd = inputEnd,
+    inputStart = inputStart,
+  )
 
   override fun close() {
     val cctxPointerToClose = dctxPointer
@@ -40,8 +51,12 @@ internal class JniZstdDecompressor : ZstdDecompressor() {
   private external fun decompressStream(
     jniPointer: Long,
     dctxPointer: Long,
-    output: UnsafeCursor,
-    input: UnsafeCursor,
+    outputByteArray: ByteArray,
+    outputEnd: Int,
+    outputStart: Int,
+    inputByteArray: ByteArray,
+    inputEnd: Int,
+    inputStart: Int,
   ): Long
 
   private external fun close(cctxPointer: Long)

--- a/okio-zstd/src/nativeMain/kotlin/okio/zstd/NativeZstdDecompressor.kt
+++ b/okio-zstd/src/nativeMain/kotlin/okio/zstd/NativeZstdDecompressor.kt
@@ -23,7 +23,6 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.usePinned
-import okio.Buffer.UnsafeCursor
 import okio.zstd.internal.ZSTD_createDCtx
 import okio.zstd.internal.ZSTD_decompressStream
 import okio.zstd.internal.ZSTD_freeDCtx
@@ -37,21 +36,25 @@ internal class NativeZstdDecompressor : ZstdDecompressor() {
     }
 
   override fun decompressStream(
-    output: UnsafeCursor,
-    input: UnsafeCursor,
+    outputByteArray: ByteArray,
+    outputEnd: Int,
+    outputStart: Int,
+    inputByteArray: ByteArray,
+    inputEnd: Int,
+    inputStart: Int,
   ): Long {
     memScoped {
-      output.data!!.usePinned { outputDataPinned ->
-        input.data!!.usePinned { inputDataPinned ->
-          val outputStart = output.start.toULong()
-          val outputEnd = output.end.toULong()
+      outputByteArray.usePinned { outputDataPinned ->
+        inputByteArray.usePinned { inputDataPinned ->
+          val outputStart = outputStart.toULong()
+          val outputEnd = outputEnd.toULong()
           val zstdOutput = alloc<ZSTD_outBuffer>()
           zstdOutput.dst = outputDataPinned.addressOf(0)
           zstdOutput.pos = outputStart
           zstdOutput.size = outputEnd
 
-          val inputStart = input.start.toULong()
-          val inputEnd = input.end.toULong()
+          val inputStart = inputStart.toULong()
+          val inputEnd = inputEnd.toULong()
           val zstdInput = alloc<ZSTD_inBuffer>()
           zstdInput.src = inputDataPinned.addressOf(0)
           zstdInput.pos = inputStart


### PR DESCRIPTION
We should be able to split the Zstd+KMP stuff from the Zstd+Okio stuff.