### PR TITLE
Build aarch64 Windows dll

### DIFF
--- a/zstd-kmp/build.zig
+++ b/zstd-kmp/build.zig
@@ -10,6 +10,7 @@ pub fn build(b: *std.Build) !void {
   try setupTarget(b, &deleteLib.step, .macos, .aarch64, "aarch64");
   try setupTarget(b, &deleteLib.step, .macos, .x86_64, "x86_64");
   try setupTarget(b, &deleteLib.step, .windows, .x86_64, "amd64");
+  try setupTarget(b, &deleteLib.step, .windows, .aarch64, "aarch64");
 }
 
 fn setupTarget(b: *std.Build, step: *std.Build.Step, tag: std.Target.Os.Tag, arch: std.Target.Cpu.Arch, dir: []const u8) !void {


### PR DESCRIPTION
This enables running under JVM on Windows on ARM devices, where previously #28 occurs.
My only concern is that `os.arch` might return `arm64` rather than `aarch64`. I'm checking this now.