### PR TITLE
Disable host-side unit tests

### DIFF
--- a/zstd-kmp-okio/build.gradle.kts
+++ b/zstd-kmp-okio/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.api.variant.HasUnitTestBuilder
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
@@ -67,6 +68,13 @@ dependencies {
       artifactType("aar")
     }
   )
+}
+
+// Disable host-side unit tests. Testing is done with device instrumentation tests.
+androidComponents {
+  beforeVariants {
+    (it as HasUnitTestBuilder).enableUnitTest = false
+  }
 }
 
 android {

--- a/zstd-kmp/build.gradle.kts
+++ b/zstd-kmp/build.gradle.kts
@@ -1,4 +1,5 @@
 import co.touchlab.cklib.gradle.CompileToBitcode.Language.C
+import com.android.build.api.variant.HasUnitTestBuilder
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
@@ -99,6 +100,13 @@ cklib {
         "-Wno-unused-parameter" /* for windows 32 */
       )
     )
+  }
+}
+
+// Disable host-side unit tests. Testing is done with device instrumentation tests.
+androidComponents {
+  beforeVariants {
+    (it as HasUnitTestBuilder).enableUnitTest = false
   }
 }
 


### PR DESCRIPTION
All testing is done with device instrumentation, and this makes a normal 'build' task succeed.

Should fix https://github.com/JakeWharton/prerelease-testing/pull/117