### PR TITLE
Delete `RandomSource`

### DIFF
--- a/zstd-kmp-okio/src/commonTest/kotlin/com/squareup/zstd/okio/OkioZstdTesting.kt
+++ b/zstd-kmp-okio/src/commonTest/kotlin/com/squareup/zstd/okio/OkioZstdTesting.kt
@@ -15,35 +15,11 @@
  */
 package com.squareup.zstd.okio
 
-import kotlin.random.Random
 import okio.Buffer
 import okio.ByteString
-import okio.Source
-import okio.Timeout
-
-/** Returns [byteCount] bytes from [random]. */
-class RandomSource(
-  val random: Random,
-  byteCount: Int,
-) : Source {
-  private var remaining = byteCount.toLong()
-
-  override fun read(sink: Buffer, byteCount: Long): Long {
-    val toRead = minOf(byteCount, remaining)
-    if (toRead == 0L) return -1L
-    sink.write(random.nextBytes(toRead.toInt()))
-    remaining -= toRead
-    return toRead
-  }
-
-  override fun timeout() = Timeout.Companion.NONE
-
-  override fun close() {
-  }
-}
 
 /** Decompress using a different implementation, where available. */
 expect fun Buffer.referenceDecompress(): ByteString
 
 /** Compress using a different implementation, where available. */
-expect fun Source.referenceCompress(): Buffer
+expect fun ByteArray.referenceCompress(): Buffer

--- a/zstd-kmp-okio/src/commonTest/kotlin/com/squareup/zstd/okio/ZstdCompressSinkTest.kt
+++ b/zstd-kmp-okio/src/commonTest/kotlin/com/squareup/zstd/okio/ZstdCompressSinkTest.kt
@@ -20,6 +20,7 @@ import assertk.assertions.isEqualTo
 import kotlin.random.Random
 import kotlin.test.Test
 import okio.Buffer
+import okio.ByteString.Companion.toByteString
 import okio.buffer
 import okio.use
 
@@ -42,9 +43,9 @@ class ZstdCompressSinkTest {
   private fun testRoundTrip(byteCount: Int) {
     val compressed = Buffer()
     compressed.zstdCompress().buffer().use {
-      it.writeAll(RandomSource(Random(1), byteCount))
+      it.write(Random(1).nextBytes(byteCount))
     }
     assertThat(compressed.referenceDecompress())
-      .isEqualTo(RandomSource(Random(1), byteCount).buffer().readByteString())
+      .isEqualTo(Random(1).nextBytes(byteCount).toByteString())
   }
 }

--- a/zstd-kmp-okio/src/commonTest/kotlin/com/squareup/zstd/okio/ZstdDecompressSourceTest.kt
+++ b/zstd-kmp-okio/src/commonTest/kotlin/com/squareup/zstd/okio/ZstdDecompressSourceTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import okio.Buffer
 import okio.ByteString
+import okio.ByteString.Companion.toByteString
 import okio.EOFException
 import okio.IOException
 import okio.buffer
@@ -45,7 +46,7 @@ class ZstdDecompressSourceTest {
   }
 
   private fun testRoundTrip(byteCount: Int) {
-    val compressed = RandomSource(Random(1), byteCount)
+    val compressed = Random(1).nextBytes(byteCount)
       .referenceCompress()
 
     val decompressed = compressed.zstdDecompress().buffer().use {
@@ -53,12 +54,12 @@ class ZstdDecompressSourceTest {
     }
 
     assertThat(decompressed)
-      .isEqualTo(RandomSource(Random(1), byteCount).buffer().readByteString())
+      .isEqualTo(Random(1).nextBytes(byteCount).toByteString())
   }
 
   @Test
   fun sourceIsTruncated() {
-    val compressed = RandomSource(Random(1), 1024)
+    val compressed = Random(1).nextBytes(1024)
       .referenceCompress()
     val truncated = Buffer()
     truncated.write(compressed, compressed.size - 1L)

--- a/zstd-kmp-okio/src/jniTest/kotlin/com/squareup/zstd/okio/JniZstdCompressSinkTest.kt
+++ b/zstd-kmp-okio/src/jniTest/kotlin/com/squareup/zstd/okio/JniZstdCompressSinkTest.kt
@@ -63,7 +63,7 @@ class JniZstdCompressSinkTest {
     val zstdCompressSink = ZstdCompressSink(sink.buffer(), compressor)
 
     assertFailsWith<IOException> {
-      zstdCompressSink.buffer().writeAll(RandomSource(Random(1), 1024 * 1024))
+      zstdCompressSink.buffer().write(Random(1).nextBytes(1024 * 1024))
     }
     assertThat(zstdCompressSink.closed).isFalse()
     assertThat(compressor.cctxPointer).isNotEqualTo(0L)

--- a/zstd-kmp-okio/src/jniTest/kotlin/com/squareup/zstd/okio/JniZstdDecompressSourceTest.kt
+++ b/zstd-kmp-okio/src/jniTest/kotlin/com/squareup/zstd/okio/JniZstdDecompressSourceTest.kt
@@ -62,7 +62,7 @@ class JniZstdDecompressSourceTest {
   /** Confirm we can clean up even if reads aren't working. */
   @Test
   fun readFailure() {
-    val delegate = RandomSource(Random(1), 1024 * 1024)
+    val delegate = Random(1).nextBytes(1024 * 1024)
       .referenceCompress()
     var sourceClosed = false
     var explode = false

--- a/zstd-kmp-okio/src/jniTest/kotlin/com/squareup/zstd/okio/JniZstdTesting.kt
+++ b/zstd-kmp-okio/src/jniTest/kotlin/com/squareup/zstd/okio/JniZstdTesting.kt
@@ -19,7 +19,6 @@ import com.github.luben.zstd.ZstdInputStream
 import com.github.luben.zstd.ZstdOutputStream
 import okio.Buffer
 import okio.ByteString
-import okio.Source
 import okio.buffer
 import okio.sink
 import okio.source
@@ -42,10 +41,10 @@ actual fun Buffer.referenceDecompress(): ByteString {
 /**
  * Compress using Zstd-jni.
  */
-actual fun Source.referenceCompress(): Buffer {
+actual fun ByteArray.referenceCompress(): Buffer {
   val result = Buffer()
   ZstdOutputStream(result.outputStream()).sink().buffer().use {
-    it.writeAll(this@referenceCompress)
+    it.write(this@referenceCompress)
   }
   return result
 }

--- a/zstd-kmp-okio/src/nativeTest/kotlin/com/squareup/zstd/okio/NativeZstdTesting.kt
+++ b/zstd-kmp-okio/src/nativeTest/kotlin/com/squareup/zstd/okio/NativeZstdTesting.kt
@@ -17,7 +17,6 @@ package com.squareup.zstd.okio
 
 import okio.Buffer
 import okio.ByteString
-import okio.Source
 import okio.buffer
 import okio.use
 
@@ -27,10 +26,10 @@ actual fun Buffer.referenceDecompress(): ByteString {
   }
 }
 
-actual fun Source.referenceCompress(): Buffer {
+actual fun ByteArray.referenceCompress(): Buffer {
   val result = Buffer()
   result.zstdCompress().buffer().use {
-    it.writeAll(this@referenceCompress)
+    it.write(this@referenceCompress)
   }
   return result
 }


### PR DESCRIPTION
It doesn't provide much value, and just complicates copying to kotlinx-io implementation.