### PR TITLE
Remove toolchain usage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,8 +8,10 @@ import org.jetbrains.dokka.DokkaConfiguration.Visibility
 import org.jetbrains.dokka.gradle.AbstractDokkaTask
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 buildscript {
   repositories {
@@ -110,16 +112,16 @@ allprojects {
     enabled = project.findProperty("signingInMemoryKey") != null
   }
 
-  plugins.withId("org.jetbrains.kotlin.multiplatform") {
-    configure<KotlinMultiplatformExtension> {
-      jvmToolchain(8)
+  val javaVersion = JavaVersion.VERSION_1_8
+  tasks.withType(KotlinJvmCompile::class.java).configureEach {
+    compilerOptions {
+      freeCompilerArgs.add("-Xjdk-release=$javaVersion")
+      jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
     }
   }
-
-  plugins.withId("org.jetbrains.kotlin.jvm") {
-    configure<KotlinJvmProjectExtension> {
-      jvmToolchain(8)
-    }
+  tasks.withType(JavaCompile::class.java).configureEach {
+    sourceCompatibility = javaVersion.toString()
+    targetCompatibility = javaVersion.toString()
   }
 
   plugins.withId("com.vanniktech.maven.publish.base") {


### PR DESCRIPTION
Before/after:
```
❯ md5sum build/testMaven/com/squareup/zstd/zstd-kmp-jvm/1.0.0-SNAPSHOT/zstd-kmp-jvm-1.0.0-20250930.172102-1.jar
4e690c13ff199b9f0d91e25c7b20179e  build/testMaven/com/squareup/zstd/zstd-kmp-jvm/1.0.0-SNAPSHOT/zstd-kmp-jvm-1.0.0-20250930.172102-1.jar

❯ md5sum build/testMaven/com/squareup/zstd/zstd-kmp-jvm/1.0.0-SNAPSHOT/zstd-kmp-jvm-1.0.0-20250930.172941-2.jar
4e690c13ff199b9f0d91e25c7b20179e  build/testMaven/com/squareup/zstd/zstd-kmp-jvm/1.0.0-SNAPSHOT/zstd-kmp-jvm-1.0.0-20250930.172941-2.jar

❯ md5sum build/testMaven/com/squareup/zstd/zstd-kmp-jvm/1.0.0-SNAPSHOT/zstd-kmp-jvm-1.0.0-20250930.172102-1.module
cafa06253a2bd31f6b383c2a6333aeba  build/testMaven/com/squareup/zstd/zstd-kmp-jvm/1.0.0-SNAPSHOT/zstd-kmp-jvm-1.0.0-20250930.172102-1.module

❯ md5sum build/testMaven/com/squareup/zstd/zstd-kmp-jvm/1.0.0-SNAPSHOT/zstd-kmp-jvm-1.0.0-20250930.172941-2.module
cafa06253a2bd31f6b383c2a6333aeba  build/testMaven/com/squareup/zstd/zstd-kmp-jvm/1.0.0-SNAPSHOT/zstd-kmp-jvm-1.0.0-20250930.172941-2.module
```