### PR TITLE
Only ship one .so file in Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## Unreleased
 
+ * Fix: Don't ship an unused copy of `libzstd.so` in our Android APKs. We were inadvertently
+   packaging our Android `.aar` libraries with both `libzstd-kmp.so` and `libzstd.so`, but only
+   ever using the first one.
+
+
 ## Version 0.3.0
 
 _2025-07-18_
 
  * Fix: Support JDK back to version 8.
  * Fix: Support Windows for JVM and Kotlin/Native.
-*  Upgrade: [Okio 3.15.0][okio_3_15_0].
+ * Upgrade: [Okio 3.15.0][okio_3_15_0].
 
 
 ## Version 0.2.0

--- a/zstd-kmp/build.gradle.kts
+++ b/zstd-kmp/build.gradle.kts
@@ -129,6 +129,7 @@ android {
         arguments("-DANDROID_TOOLCHAIN=clang", "-DANDROID_STL=c++_static")
         cFlags("-fstrict-aliasing")
         cppFlags("-fstrict-aliasing")
+        targets("zstd-kmp")
       }
     }
   }


### PR DESCRIPTION
We weren't selecting which .so file we wanted in the build, so we got all of 'em.