### PR TITLE
Support building with AGP 9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,11 @@ android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 
+# New AGP KMP plugin blocked by https://issuetracker.google.com/issues/439746703.
+android.builtInKotlin=false
+# Needed for above.
+android.newDsl=false
+
 systemProp.org.gradle.internal.http.socketTimeout=120000
 
 kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
There's no point in upgrading since we can't use AGP's new KMP support. However, adding these properties now allows building with the AGP 9 alphas for testing purposes.